### PR TITLE
Fix for #70 (MethodCall) => Null' is not a subtype of type '((MethodCall) => Future<dynamic>)

### DIFF
--- a/lib/blue_thermal_printer.dart
+++ b/lib/blue_thermal_printer.dart
@@ -32,7 +32,7 @@ class BlueThermalPrinter {
   //Stream<MethodCall> get _methodStream => _methodStreamController.stream;
 
   BlueThermalPrinter._() {
-    _channel.setMethodCallHandler((MethodCall call) {
+    _channel.setMethodCallHandler((MethodCall call) async {
       _methodStreamController.add(call);
     });
   }

--- a/lib/blue_thermal_printer.dart
+++ b/lib/blue_thermal_printer.dart
@@ -34,7 +34,7 @@ class BlueThermalPrinter {
   BlueThermalPrinter._() {
     _channel.setMethodCallHandler((MethodCall call) {
       _methodStreamController.add(call);
-    } as Future<dynamic> Function(MethodCall)?);
+    }
   }
 
   static BlueThermalPrinter _instance = new BlueThermalPrinter._();

--- a/lib/blue_thermal_printer.dart
+++ b/lib/blue_thermal_printer.dart
@@ -34,7 +34,7 @@ class BlueThermalPrinter {
   BlueThermalPrinter._() {
     _channel.setMethodCallHandler((MethodCall call) {
       _methodStreamController.add(call);
-    }
+    });
   }
 
   static BlueThermalPrinter _instance = new BlueThermalPrinter._();


### PR DESCRIPTION
I've just fixed the default constructor for sound null safety as suggested by https://github.com/kakzaki/blue_thermal_printer/issues/70#issuecomment-813293797
This avoids both run-time and compile-time errors and works in a real environment.